### PR TITLE
Remove userId requirement from group calls

### DIFF
--- a/group.go
+++ b/group.go
@@ -28,13 +28,5 @@ func (msg Group) Validate() error {
 		}
 	}
 
-	if len(msg.UserId) == 0 && len(msg.AnonymousId) == 0 {
-		return FieldError{
-			Type:  "analytics.Group",
-			Name:  "UserId",
-			Value: msg.UserId,
-		}
-	}
-
 	return nil
 }

--- a/group_test.go
+++ b/group_test.go
@@ -22,26 +22,6 @@ func TestGroupMissingGroupId(t *testing.T) {
 	}
 }
 
-func TestGroupMissingUserId(t *testing.T) {
-	group := Group{
-		GroupId: "1",
-	}
-
-	if err := group.Validate(); err == nil {
-		t.Error("validating an invalid group object succeeded:", group)
-
-	} else if e, ok := err.(FieldError); !ok {
-		t.Error("invalid error type returned when validating group:", err)
-
-	} else if e != (FieldError{
-		Type:  "analytics.Group",
-		Name:  "UserId",
-		Value: "",
-	}) {
-		t.Error("invalid error value returned when validating group:", err)
-	}
-}
-
 func TestGroupValidWithUserId(t *testing.T) {
 	group := Group{
 		GroupId: "1",


### PR DESCRIPTION
Group calls map to [objects](https://customer.io/docs/journeys/objects/) in Customer.io. It's completely possible to register objects (and associated traits) without being related to a user.