### PR TITLE
Traits.SetCreatedAt converts time.Time to Unix timestamp

### DIFF
--- a/traits.go
+++ b/traits.go
@@ -25,7 +25,7 @@ func (t Traits) SetBirthday(date time.Time) Traits {
 }
 
 func (t Traits) SetCreatedAt(date time.Time) Traits {
-	return t.Set("createdAt", date)
+	return t.Set("createdAt", date.Unix())
 }
 
 func (t Traits) SetDescription(desc string) Traits {

--- a/traits_test.go
+++ b/traits_test.go
@@ -8,6 +8,7 @@ import (
 
 func TestTraitsSimple(t *testing.T) {
 	date := time.Now()
+	dateInUnix := date.Unix()
 	text := "ABC"
 	number := 42
 
@@ -19,7 +20,7 @@ func TestTraitsSimple(t *testing.T) {
 		"age":         {Traits{"age": number}, func(t Traits) { t.SetAge(number) }},
 		"avatar":      {Traits{"avatar": text}, func(t Traits) { t.SetAvatar(text) }},
 		"birthday":    {Traits{"birthday": date}, func(t Traits) { t.SetBirthday(date) }},
-		"createdAt":   {Traits{"createdAt": date}, func(t Traits) { t.SetCreatedAt(date) }},
+		"createdAt":   {Traits{"createdAt": dateInUnix}, func(t Traits) { t.SetCreatedAt(date) }},
 		"description": {Traits{"description": text}, func(t Traits) { t.SetDescription(text) }},
 		"email":       {Traits{"email": text}, func(t Traits) { t.SetEmail(text) }},
 		"firstName":   {Traits{"firstName": text}, func(t Traits) { t.SetFirstName(text) }},


### PR DESCRIPTION
## Before

When uploading a `time.Time` value to the reserved `createdAt` attribute, the API succeeds with status `200 OK`, but displays an `Invalid Date` when viewing the `People` tab in Journeys.

In fact, attempting to `Round` or `Truncate` the `time.Time` in any fashion has the same results.

![Screenshot 2024-12-13 at 8 50 13 AM](https://github.com/user-attachments/assets/d9cd8749-6b32-4332-9507-9b394b334ed9)
![Screenshot 2024-12-13 at 8 49 46 AM](https://github.com/user-attachments/assets/48768482-0dd1-468e-bfc2-7c757b48711c)

## After

I then noticed that a default segment documents `created_at` to expect a UNIX timestamp.

![Screenshot 2024-12-13 at 8 53 39 AM](https://github.com/user-attachments/assets/b77a76ba-c2fd-44dd-9771-ed43d422d147)

When instead manually setting the `createdAt` as shown below, I instead got the desired result.

```go
identify := analytics.Identify{
	Traits: analytics.NewTraits().
		Set("createdAt", time.Now().Unix()),
	UserId: userID,
}
```

## Result

![Screenshot 2024-12-13 at 8 55 03 AM](https://github.com/user-attachments/assets/70d49404-63a6-49bf-b7a4-b6602dae12c1)

![Screenshot 2024-12-13 at 8 55 23 AM](https://github.com/user-attachments/assets/7474c418-fd40-4275-b503-28f3f995f2aa)