### PR TITLE
Upgrade yaml.v2 from v2.2.1 to v2.4.0 to fix 3 CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,5 +16,5 @@ require (
 	gopkg.in/go-playground/assert.v1 v1.2.1 // indirect
 	gopkg.in/go-playground/mold.v2 v2.2.0 // indirect
 	gopkg.in/validator.v2 v2.0.0-20180514200540-135c24b11c19 // indirect
-	gopkg.in/yaml.v2 v2.2.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -26,5 +26,6 @@ gopkg.in/go-playground/mold.v2 v2.2.0 h1:Y4IYB4/HYQfuq43zaKh6vs9cVelLE9qbqe2fkyf
 gopkg.in/go-playground/mold.v2 v2.2.0/go.mod h1:XMyyRsGtakkDPbxXbrA5VODo6bUXyvoDjLd5l3T0XoA=
 gopkg.in/validator.v2 v2.0.0-20180514200540-135c24b11c19 h1:WB265cn5OpO+hK3pikC9hpP1zI/KTwmyMFKloW9eOVc=
 gopkg.in/validator.v2 v2.0.0-20180514200540-135c24b11c19/go.mod h1:o4V0GXN9/CAmCsvJ0oXYZvrZOe7syiDZSN1GWGZTGzc=
-gopkg.in/yaml.v2 v2.2.1 h1:mUhvW9EsL+naU5Q3cakzfE91YhliOondGd6ZrsDBHQE=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
## Summary

Upgrade the indirect dependency `gopkg.in/yaml.v2` from v2.2.1 to v2.4.0 to resolve 3 known security vulnerabilities (CVE-2022-3064, CVE-2019-11254, CVE-2021-4235). The dependency is transitive — pulled in via `segmentio/conf` → `segmentio/objconv` — and is not imported directly by any source code in this repo.

## Subtasks shipped

- **CDP-5893**: Upgrade yaml.v2 to v2.4.0 — edited `go.mod`, ran `go mod tidy`, verified tests pass and modules verify

## Linear

https://linear.app/customerio/issue/CDP-5767/cdp-analytics-go-fix-3rd-party-vulnerabilities-non-breaking

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only change that updates an indirect YAML parser version and associated checksums; no application code is modified.
> 
> **Overview**
> Upgrades the indirect dependency `gopkg.in/yaml.v2` from `v2.2.1` to `v2.4.0` in `go.mod` and refreshes `go.sum` entries accordingly, addressing known vulnerabilities without changing runtime code paths in this repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4078b6a51b77cbc7ac38d88ff42854ec8fc53a67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->